### PR TITLE
Create a functionality to have imports which change the note type

### DIFF
--- a/Specialfields21/__init__.py
+++ b/Specialfields21/__init__.py
@@ -295,6 +295,7 @@ def _mid(self, srcMid):
 
 Anki2Importer._mid = _mid
 
+
 def _did(self, did: int):
     "Given did in src col, return local id."
     # already converted?
@@ -343,4 +344,6 @@ def _did(self, did: int):
     # add to deck map and return
     self._decks[did] = newid
     return newid
+
+
 Anki2Importer._did = _did

--- a/Specialfields21/__init__.py
+++ b/Specialfields21/__init__.py
@@ -6,6 +6,7 @@ from aqt.utils import showWarning
 
 from . import dialog
 from .config import getUserOption
+from .note_type_mapping import create_mapping_on_field_name_equality
 
 # #########################################################
 #
@@ -288,7 +289,7 @@ def _did(self, did: int):
         self._did(idInSrc)
     # if target is a filtered deck, we'll need a new deck name
     deck = self.dst.decks.byName(name)
-    
+
     is_new = not bool(deck)
 
     if deck and deck["dyn"]:

--- a/Specialfields21/__init__.py
+++ b/Specialfields21/__init__.py
@@ -64,7 +64,9 @@ def newImportNotes(self) -> None:
     for i in a:
         fields = i["flds"]
         for n in fields:
-            if n['name'] in getUserOptionSpecial("Special field", []) or getUserOptionSpecial("All fields are special", False):
+            if n["name"] in getUserOptionSpecial(
+                "Special field", []
+            ) or getUserOptionSpecial("All fields are special", False):
                 midCheck.append(str(i["id"]))
     ########################################################################
 
@@ -97,7 +99,9 @@ def newImportNotes(self) -> None:
                 oldNid, oldMod, oldMid = self._notes[note[GUID]]
                 # will update if incoming note more recent
 
-                if oldMod < note[MOD] or (not getUserOptionSpecial("update only if newer", True)):
+                if oldMod < note[MOD] or (
+                    not getUserOptionSpecial("update only if newer", True)
+                ):
                     # safe if note types identical
                     if oldMid == note[MID]:
                         # incoming note should use existing id
@@ -108,12 +112,16 @@ def newImportNotes(self) -> None:
                         dirty.append(note[0])
                     else:
                         ######### note type mapping
+                        updateNoteType = getUserOptionSpecial("update note styling")
+
                         old_model = self.dst.models.get(oldMid)
                         target_model = self.dst.models.get(note[MID])
 
-                        mapping = create_mapping_on_field_name_equality(old_model, target_model)
+                        mapping = create_mapping_on_field_name_equality(
+                            old_model, target_model
+                        )
 
-                        if mapping:
+                        if updateNoteType and mapping:
                             self.dst.models.change(
                                 old_model,
                                 [note[NID]],
@@ -139,7 +147,7 @@ def newImportNotes(self) -> None:
 
     for note in update:
         oldnote = mw.col.getNote(note[0])
-        newTags = [t for t in note[5].replace('\u3000', ' ').split(" ") if t]
+        newTags = [t for t in note[5].replace("\u3000", " ").split(" ") if t]
         for tag in oldnote.tags:
             for i in newTags:
                 if i.lower() == tag.lower():
@@ -153,7 +161,7 @@ def newImportNotes(self) -> None:
             model = mw.col.models.get(mid)
             specialFields = getUserOptionSpecial("Special field", [])
             if getUserOptionSpecial("All fields are special", False):
-                specialFields = [fld['name'] for fld in model['flds']]
+                specialFields = [fld["name"] for fld in model["flds"]]
             # if this note belongs to a model with "Special Field"
             trow = list(note)
             for i in specialFields:
@@ -167,19 +175,20 @@ def newImportNotes(self) -> None:
                     # valueLocal = mw.col.getNote(note[0]).values()
                     # splitRow[indexOfField] = valueLocal[indexOfField]
 
-                    finalrow = ''
+                    finalrow = ""
                     count = 0
                     for a in splitRow:
                         if count == fieldOrd:
                             finalrow += str(fields[fieldOrd]) + "\x1f"
                         else:
-                            finalrow += a+"\x1f"
+                            finalrow += a + "\x1f"
                         count = count + 1
 
                     def rreplace(s, old, new, occurrence):
                         li = s.rsplit(old, occurrence)
                         return new.join(li)
-                    finarow = rreplace(finalrow, """\x1f""", '', 1)
+
+                    finarow = rreplace(finalrow, """\x1f""", "", 1)
                     note[6] = str(finarow)
                     # if note[0] == 1558556384609: #FOR TROUBLE SHOOTING ! Change to the card.id you are uncertain about
 
@@ -193,15 +202,17 @@ def newImportNotes(self) -> None:
     if dupesIgnored:
         self.log.append(
             _("Notes that could not be imported as note type has changed: %d")
-            % len(dupesIgnored))
+            % len(dupesIgnored)
+        )
     if update:
-        self.log.append(
-            _("Notes updated, as file had newer version: %d") % len(update))
+        self.log.append(_("Notes updated, as file had newer version: %d") % len(update))
     if add:
         self.log.append(_("Notes added from file: %d") % len(add))
     if dupesIdentical:
-        self.log.append(_("Notes skipped, as they're already in your collection: %d") %
-                        len(dupesIdentical))
+        self.log.append(
+            _("Notes skipped, as they're already in your collection: %d")
+            % len(dupesIdentical)
+        )
 
     self.log.append("")
 
@@ -238,7 +249,7 @@ def newImportNotes(self) -> None:
         for importedDid, importedDeck in ((d["id"], d) for d in self.src.decks.all()):
             localDid = self._did(importedDid)
             localDeck = self.dst.decks.get(localDid)
-            localDeck['desc'] = importedDeck['desc']
+            localDeck["desc"] = importedDeck["desc"]
             self.dst.decks.save(localDeck)
 
 
@@ -279,7 +290,9 @@ def _mid(self, srcMid):
         dstScm = self.dst.models.scmhash(dstModel)
         if srcScm == dstScm:
             # copy styling changes over if newer
-            if updateNoteType or (updateNoteType is None and srcModel["mod"] > dstModel["mod"]):
+            if updateNoteType or (
+                updateNoteType is None and srcModel["mod"] > dstModel["mod"]
+            ):
                 model = srcModel.copy()
                 model["mod"] = max(srcModel["mod"], dstModel["mod"])
                 model["id"] = mid

--- a/Specialfields21/note_type_mapping.py
+++ b/Specialfields21/note_type_mapping.py
@@ -34,7 +34,7 @@ class FieldMapping(NoteTypeMapping):
         self.fld_mappings = fld_mappings
 
     def get_card_type_map(self) -> Dict[int, Optional[int]]:
-        result = {} 
+        result = {}
 
         for i in range(self.tmpl_amount):
             result[i] = self.map_card_type(i)
@@ -72,7 +72,9 @@ def templates_match(model: NoteType, other_model: NoteType) -> bool:
     return True
 
 
-def create_mapping_on_field_name_equality(from_model: NoteType, to_model: NoteType) -> Optional[NoteTypeMapping]:
+def create_mapping_on_field_name_equality(
+    from_model: NoteType, to_model: NoteType
+) -> Optional[NoteTypeMapping]:
     if not templates_match(from_model, to_model):
         return None
 

--- a/Specialfields21/note_type_mapping.py
+++ b/Specialfields21/note_type_mapping.py
@@ -37,7 +37,7 @@ class FieldMapping(NoteTypeMapping):
         result = {} 
 
         for i in range(self.tmpl_amount):
-            result[i] = i
+            result[i] = self.map_card_type(i)
 
         return result
 

--- a/Specialfields21/note_type_mapping.py
+++ b/Specialfields21/note_type_mapping.py
@@ -1,0 +1,70 @@
+from typing import Optional, Dict
+from abc import ABC
+
+from anki.models import NoteType
+from aqt.utils import showText
+from aqt import mw
+
+
+class NoteTypeMapping(ABC):
+    def map_card_type(tmpl_id: int) -> Optional[int]:
+        pass
+
+    def map_field(fld_id: int) -> Optional[int]:
+        pass
+
+
+class FieldMapping(NoteTypeMapping):
+    def __init__(
+        self,
+        tmpl_amount: int,
+        fld_mappings: Dict[int, Optional[int]],
+    ):
+        self.tmpl_amount = tmpl_amount
+        self.fld_mappings = fld_mappings
+
+    def map_card_type(self, tmpl_id: int) -> Optional[int]:
+        return tmpl_id if tmpl_id < self.tmpl_amount else None
+
+    def map_field(self, fld_id: int) -> Optional[int]:
+        return self.fld_mappings[fld_id] if fld_id in self.fld_mappings else fld_id
+
+
+def get_template_name(tmpl: Dict[str, any]) -> str:
+    return tmpl["name"]
+
+
+def get_field_name(fld: Dict[str, any]) -> str:
+    return fld["name"]
+
+
+def templates_match(model: NoteType, other_model: NoteType) -> bool:
+    if len(model["tmpls"]) != len(other_model["tmpls"]):
+        return False
+
+    template_names = map(get_template_name, model["tmpls"])
+
+    for idx, name in enumerate(template_names):
+        if name != get_template_name(other_model["tmpls"][idx]):
+            return False
+
+    return True
+
+
+def create_mapping_on_field_name_equality(src_model: NoteType, dst_model: NoteType) -> Optional[NoteTypeMapping]:
+    if not templates_match(src_model, dst_model):
+        return None
+
+    src_fields = list(map(get_field_name, src_model["flds"]))
+    dst_fields = list(map(get_field_name, dst_model["flds"]))
+
+    field_mappings = {}
+
+    for index, field_name in enumerate(src_fields):
+        try:
+            index_in_dst = dst_fields.index(field_name)
+            field_mappings[index] = index_in_dst
+        except ValueError:
+            field_mappings[index] = None
+
+    return FieldMapping(len(src_model["tmpls"]), field_mappings)

--- a/Specialfields21/note_type_mapping.py
+++ b/Specialfields21/note_type_mapping.py
@@ -7,24 +7,45 @@ from aqt import mw
 
 
 class NoteTypeMapping(ABC):
-    def map_card_type(tmpl_id: int) -> Optional[int]:
+    destination: NoteType
+
+    def get_card_type_map(self) -> Dict[int, Optional[int]]:
         pass
 
-    def map_field(fld_id: int) -> Optional[int]:
+    def map_card_type(self, tmpl_id: int) -> Optional[int]:
+        pass
+
+    def get_field_map(self) -> Dict[int, Optional[int]]:
+        pass
+
+    def map_field(self, fld_id: int) -> Optional[int]:
         pass
 
 
 class FieldMapping(NoteTypeMapping):
     def __init__(
         self,
+        to_model: NoteType,
         tmpl_amount: int,
         fld_mappings: Dict[int, Optional[int]],
     ):
+        self.destination = to_model
         self.tmpl_amount = tmpl_amount
         self.fld_mappings = fld_mappings
 
+    def get_card_type_map(self) -> Dict[int, Optional[int]]:
+        result = {} 
+
+        for i in range(self.tmpl_amount):
+            result[i] = i
+
+        return result
+
     def map_card_type(self, tmpl_id: int) -> Optional[int]:
         return tmpl_id if tmpl_id < self.tmpl_amount else None
+
+    def get_field_map(self) -> Dict[int, Optional[int]]:
+        return self.fld_mappings
 
     def map_field(self, fld_id: int) -> Optional[int]:
         return self.fld_mappings[fld_id] if fld_id in self.fld_mappings else fld_id
@@ -51,12 +72,12 @@ def templates_match(model: NoteType, other_model: NoteType) -> bool:
     return True
 
 
-def create_mapping_on_field_name_equality(src_model: NoteType, dst_model: NoteType) -> Optional[NoteTypeMapping]:
-    if not templates_match(src_model, dst_model):
+def create_mapping_on_field_name_equality(from_model: NoteType, to_model: NoteType) -> Optional[NoteTypeMapping]:
+    if not templates_match(from_model, to_model):
         return None
 
-    src_fields = list(map(get_field_name, src_model["flds"]))
-    dst_fields = list(map(get_field_name, dst_model["flds"]))
+    src_fields = list(map(get_field_name, from_model["flds"]))
+    dst_fields = list(map(get_field_name, to_model["flds"]))
 
     field_mappings = {}
 
@@ -67,4 +88,4 @@ def create_mapping_on_field_name_equality(src_model: NoteType, dst_model: NoteTy
         except ValueError:
             field_mappings[index] = None
 
-    return FieldMapping(len(src_model["tmpls"]), field_mappings)
+    return FieldMapping(to_model, len(from_model["tmpls"]), field_mappings)


### PR DESCRIPTION
Normally, when you export, change the note type of a note, and try to re-import the deck, Anki will refuse to import the card, and complain "Skipped: Note type changed".

This PR changes the import functionality, to make this kind of import possible.
This PR was commissioned by @AnKingMed.

It respects the "Update note styling" and "Update only if newer" options in the SpecialFields dialog.