### PR TITLE
Introduce keep tags feature

### DIFF
--- a/Specialfields21/__init__.py
+++ b/Specialfields21/__init__.py
@@ -161,6 +161,21 @@ def newImportNotes(self) -> None:
 
         newTags = set(newTags)
         togetherTags = " %s " % " ".join(newTags)
+
+        ######### KEEP tags
+        keepTags = [t for t in note[5].replace("\u3000", " ").split(" ") if t]
+        for tag in oldnote.tags:
+            for i in keepTags:
+                if i.lower() == tag.lower():
+                    tag = i
+
+            if "%%keep%%" in tag:
+                keepTags.append(tag)
+
+        keepTags = set(keepTags)
+        keepTagsTogether = " %s " % " ".join(keepTags)
+        ######### /KEEP tags
+
         mid = str(note[2])
         if mid in midCheck:
             model = mw.col.models.get(mid)
@@ -201,6 +216,8 @@ def newImportNotes(self) -> None:
                     pass
         if getUserOptionSpecial("Combine tagging", False):
             note[5] = togetherTags
+        else:
+            note[5] = keepTagsTogether
 
     self.log.append(_("Notes found in file: %d") % total)
 


### PR DESCRIPTION
Combine tagging will preserve all tags upon importing.

However with this change, even if you uncheck "Combine tagging", it will preserve tags which include `%%keep%%`.