### PR TITLE
Disable the new APKG importer

### DIFF
--- a/Specialfields21/__init__.py
+++ b/Specialfields21/__init__.py
@@ -5,6 +5,7 @@ from anki.importing import Anki2Importer
 from anki.importing.anki2 import Anki2Importer
 from anki.lang import _
 from aqt import mw
+from aqt import appVersion
 
 from .config import getUserOption
 from .dialog import returnTagsText
@@ -393,3 +394,9 @@ def intTime(scale: int = 1) -> int:
 
 
 Anki2Importer._did = _did
+
+anki_version = tuple(int(p) for p in appVersion.split("."))
+if anki_version >= (2, 1, 54):
+    from .new_importer import patch_new_importer
+
+    patch_new_importer()

--- a/Specialfields21/new_importer.py
+++ b/Specialfields21/new_importer.py
@@ -1,0 +1,12 @@
+from aqt.import_export.importing import ApkgImporter
+from aqt.importing import importFile
+from aqt.main import AnkiQt
+
+# NOTE: This just disables the new APKG importer to keep the add-on working when the new import/export handling is enabled
+
+def do_import(mw: AnkiQt, path: str) -> None:
+    importFile(mw, path)
+
+
+def patch_new_importer() -> None:
+    ApkgImporter.do_import = do_import


### PR DESCRIPTION
This PR allows the add-on to continue working even when the new import/export handling is enabled, by simply disabling the new APKG importer and falling back to the old one (which can be patched by the add-on to do its job).

I think it's worth documenting this in the changelog.

Discussed here: https://www.notion.so/Special-Fields-c8df605b26c14b8ba80fc78b70f36524